### PR TITLE
[FIX] fix spaces in arguments (warning in README.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+WARNING : The space will not work if msg.content cannot be modified
+In that case another string may need to be made for that
+
+----------------------------------------------------
+
 you manage your blob on a virtual plot
 
 a tick happens at <t:0:t> and <t:43200:t> (your timezone),

--- a/index.js
+++ b/index.js
@@ -55,6 +55,10 @@ client.on('ready', () => {
 
 
 client.on('messageCreate', msg => {
+  while (msg.content.includes("  ")) {
+    msg.content = msg.content.replace("  ", " ")
+  }
+  if(msg.content.startsWith('b! ')) msg.content = msg.content.slice(0,2) + msg.content.slice(3, undefined)
   if(!msg.content.startsWith('b!')) return;
 
   for(let a of middleware){


### PR DESCRIPTION
I tried to fix the spaces in the messages. It assumes msg.content can be modified. If it can't a local variable will need to be made